### PR TITLE
Update docker_build.yaml

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -21,8 +21,7 @@ on:
       docker-build-args:
         description: Docker build arguments
         type: string
-      runs-on:
-        default: ubuntu-latest
+      runs-on: ubuntu-latest
     secrets:
       AWS_ASSUME_ROLE:
         required: true


### PR DESCRIPTION
Error:
The workflow is not valid. In .github/workflows/release-build.yaml (Line: 30, Col: 11): Error from called workflow ovatu/actions/.github/workflows/docker_build.yaml@main (Line: 25, Col: 9): Required property is missing: type